### PR TITLE
chore: promote origins-cms to version 0.0.10

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-4nc2t-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-4nc2t-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-mitc3
+  name: jx-verify-gc-jobs-4nc2t
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-a4dmf
+    app: jx-verify-gc-jobs-mq7oq
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-ctq8l-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-ctq8l-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-acsdx
+  name: jx-verify-gc-jobs-ctq8l
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-37x8a-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-37x8a-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-n3gfy
+  name: jx-verify-gc-jobs-37x8a
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-vxvct
+    app: jx-verify-gc-jobs-rr9ot
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-gf37l-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-gf37l-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-zflgy
+  name: jx-verify-gc-jobs-gf37l
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-ingress.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-ingress.yaml
@@ -1,0 +1,26 @@
+# Source: origins-cms/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'origins-cms'
+  name: origins-cms
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: origins-cms
+                port:
+                  number: 3005
+      host: origins-cms-jx-staging.pluto.binomy.io
+  tls:
+    - hosts:
+        - origins-cms-jx-staging.pluto.binomy.io
+      secretName: "tls-pluto-binomy-io-p"

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-deploy.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-deploy.yaml
@@ -1,0 +1,70 @@
+# Source: origins-cms/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: origins-cms-origins-cms
+  labels:
+    draft: draft-app
+    chart: "origins-cms-0.0.10"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'origins-cms'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: origins-cms-origins-cms
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: origins-cms-origins-cms
+    spec:
+      serviceAccountName: origins-cms-origins-cms
+      containers:
+        - name: origins-cms
+          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.10"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: SESSION_SECRET
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: DATABASE_URL
+            - name: VERSION
+              value: 0.0.10
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 3005
+          livenessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3005
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3005
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-sa.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-sa.yaml
@@ -1,0 +1,10 @@
+# Source: origins-cms/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: origins-cms-origins-cms
+  annotations:
+    meta.helm.sh/release-name: 'origins-cms'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-secrets-secret.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-secrets-secret.yaml
@@ -1,0 +1,25 @@
+# Source: origins-cms/templates/secrets.yaml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: origins-cms-secrets
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  backendType: gcpSecretsManager
+  projectId: corded-imagery-343815
+  data:
+    - name: SESSION_SECRET
+      key: pluto-origins-cms-secrets
+      property: SESSION_SECRET
+      version: latest
+    - name: DATABASE_URL
+      key: pluto-origins-cms-secrets
+      property: DATABASE_URL
+      version: latest
+  template:
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: 'origins-cms'
+    type: Opaque

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-svc.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-svc.yaml
@@ -1,0 +1,20 @@
+# Source: origins-cms/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: origins-cms
+  labels:
+    chart: "origins-cms-0.0.10"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'origins-cms'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3005
+      targetPort: 3005
+      protocol: TCP
+      name: http
+  selector:
+    app: origins-cms-origins-cms

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
+	      <td>0.0.10</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -56,6 +56,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
+  - apiVersion: v1
+    appVersion: 0.0.10
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-03-21T01:45:21Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-03-21T01:45:21Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
+    name: origins-cms
+    repositoryName: dev
+    repositoryUrl: https://chartmuseum-jx.pluto.binomy.io
+    resourcePath: config-root/namespaces/jx-staging/origins-cms
+    version: 0.0.10
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.10
   name: origins-cms
   namespace: jx-staging
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote origins-cms to version 0.0.10

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
