### PR TITLE
chore: promote origins-cms to version 0.0.12

### DIFF
--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -8,6 +8,8 @@ repositories:
   url: https://jenkins-x-charts.github.io/repo
 - name: dev
   url: https://chartmuseum-jx.pluto.binomy.io
+- name: dev2
+  url: https://chartmuseum.pluto.binomy.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
@@ -15,7 +17,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/origins-cms
-  version: 0.0.11
+  version: 0.0.12
   name: origins-cms
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote origins-cms to version 0.0.12

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
