### PR TITLE
chore: promote stocks-ui to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-454au-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-454au-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-fjhwg
+  name: jx-verify-gc-jobs-454au
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-gozkd-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-gozkd-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-f1del
+  name: jx-verify-gc-jobs-gozkd
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-rrc8m
+    app: jx-verify-gc-jobs-efmot
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-ingress.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-ingress.yaml
@@ -1,0 +1,26 @@
+# Source: stocks-ui/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'stocks-ui'
+  name: stocks-ui
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: stocks-ui
+                port:
+                  number: 80
+      host: stocks-ui.binomy.io
+  tls:
+    - hosts:
+        - stocks-ui.binomy.io
+      secretName: "tls-binomy-io-p"

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-stocks-ui-deploy.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-stocks-ui-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: stocks-ui/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stocks-ui-stocks-ui
+  labels:
+    draft: draft-app
+    chart: "stocks-ui-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'stocks-ui'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: stocks-ui-stocks-ui
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: stocks-ui-stocks-ui
+    spec:
+      serviceAccountName: stocks-ui-stocks-ui
+      containers:
+        - name: stocks-ui
+          image: "gcr.io/corded-imagery-343815/stocks-ui:0.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.4
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-stocks-ui-sa.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-stocks-ui-sa.yaml
@@ -1,0 +1,10 @@
+# Source: stocks-ui/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stocks-ui-stocks-ui
+  annotations:
+    meta.helm.sh/release-name: 'stocks-ui'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-svc.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-svc.yaml
@@ -1,0 +1,20 @@
+# Source: stocks-ui/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: stocks-ui
+  labels:
+    chart: "stocks-ui-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'stocks-ui'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: stocks-ui-stocks-ui

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-qdz5h-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-qdz5h-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-kytn5
+  name: jx-verify-gc-jobs-qdz5h
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-s1gc0-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-s1gc0-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-940ky
+  name: jx-verify-gc-jobs-s1gc0
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-em35t
+    app: jx-verify-gc-jobs-7udea
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,12 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> stocks-ui </a></td>
+	      <td>0.0.4</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -63,6 +63,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
+  - apiVersion: v1
+    appVersion: 0.0.4
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-03-24T04:27:19Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-03-24T04:27:19Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fstocks-ui&dateRangeUnbound=both
+    name: stocks-ui
+    repositoryName: dev
+    repositoryUrl: https://chartmuseum.pluto.binomy.io
+    resourcePath: config-root/namespaces/jx-production/stocks-ui
+    version: 0.0.4
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -29,5 +29,9 @@ releases:
   - jx-values.yaml
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
+- chart: dev/stocks-ui
+  version: 0.0.4
+  name: stocks-ui
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -33,5 +33,7 @@ releases:
   version: 0.0.4
   name: stocks-ui
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -33,7 +33,5 @@ releases:
   version: 0.0.4
   name: stocks-ui
   namespace: jx-staging
-  values:
-  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -33,5 +33,7 @@ releases:
   version: 0.0.4
   name: stocks-ui
   namespace: jx-staging
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote stocks-ui to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
