### PR TITLE
chore: promote origins-cms to version 0.0.19

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-dvoen-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-dvoen-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-r7hjq
+  name: jx-verify-gc-jobs-dvoen
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-gzcxa
+    app: jx-verify-gc-jobs-hx7ts
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-lnjvs-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-lnjvs-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-lk4dx
+  name: jx-verify-gc-jobs-lnjvs
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-deploy.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: origins-cms-origins-cms
   labels:
     draft: draft-app
-    chart: "origins-cms-0.0.18"
+    chart: "origins-cms-0.0.19"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: origins-cms-origins-cms
       containers:
         - name: origins-cms
-          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.18"
+          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.19"
           imagePullPolicy: IfNotPresent
           env:
             - name: SESSION_SECRET
@@ -38,8 +38,28 @@ spec:
                 secretKeyRef:
                   name: origins-cms-db-url
                   key: DATABASE_URL
+            - name: CLOUDINARY_CLOUD_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: CLOUDINARY_CLOUD_NAME
+            - name: CLOUDINARY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: CLOUDINARY_API_KEY
+            - name: CLOUDINARY_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: CLOUDINARY_API_SECRET
+            - name: CLOUDINARY_API_FOLDER
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: CLOUDINARY_API_FOLDER
             - name: VERSION
-              value: 0.0.18
+              value: 0.0.19
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-secrets-secret.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-secrets-secret.yaml
@@ -18,6 +18,22 @@ spec:
       key: pluto-origins-cms-secrets
       property: DATABASE_URL
       version: latest
+    - name: CLOUDINARY_CLOUD_NAME
+      key: pluto-origins-cms-secrets
+      property: CLOUDINARY_CLOUD_NAME
+      version: latest
+    - name: CLOUDINARY_API_KEY
+      key: pluto-origins-cms-secrets
+      property: CLOUDINARY_API_KEY
+      version: latest
+    - name: CLOUDINARY_API_SECRET
+      key: pluto-origins-cms-secrets
+      property: CLOUDINARY_API_SECRET
+      version: latest
+    - name: CLOUDINARY_API_FOLDER
+      key: pluto-origins-cms-secrets
+      property: CLOUDINARY_API_FOLDER
+      version: latest
   template:
     metadata:
       annotations:

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-svc.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: origins-cms
   labels:
-    chart: "origins-cms-0.0.18"
+    chart: "origins-cms-0.0.19"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-7ekpc-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-7ekpc-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-zawdu
+  name: jx-verify-gc-jobs-7ekpc
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-dlzxf-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-dlzxf-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-ncblf
+  name: jx-verify-gc-jobs-dlzxf
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-swps5
+    app: jx-verify-gc-jobs-8m0s8
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
-	      <td>0.0.18</td>
+	      <td>0.0.19</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -41,17 +41,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
   - apiVersion: v1
-    appVersion: 0.0.18
+    appVersion: 0.0.19
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-03T02:50:57Z"
+    firstDeployed: "2022-04-08T14:10:55Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-03T02:50:57Z"
+    lastDeployed: "2022-04-08T14:10:55Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
     name: origins-cms
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-production/origins-cms
-    version: 0.0.18
+    version: 0.0.19
   - apiVersion: v1
     appVersion: 0.0.24
     description: Acme

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/origins-cms
-  version: 0.0.18
+  version: 0.0.19
   name: origins-cms
   namespace: jx-production
   values:


### PR DESCRIPTION
chore: promote origins-cms to version 0.0.19

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
