### PR TITLE
chore: promote stocks-ui to version 0.0.8

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-b05wi-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-b05wi-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-klayd
+  name: jx-verify-gc-jobs-b05wi
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-zlpm0-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-zlpm0-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-muh4w
+  name: jx-verify-gc-jobs-zlpm0
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-m1zgl
+    app: jx-verify-gc-jobs-lakii
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-f2zmv-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-f2zmv-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-4nxk3
+  name: jx-verify-gc-jobs-f2zmv
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-qhycq-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-qhycq-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-whbde
+  name: jx-verify-gc-jobs-qhycq
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-933uq
+    app: jx-verify-gc-jobs-w9muc
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/stocks-ui/stocks-ui-secrets-secret.yaml
+++ b/config-root/namespaces/jx-staging/stocks-ui/stocks-ui-secrets-secret.yaml
@@ -1,0 +1,21 @@
+# Source: stocks-ui/templates/secrets.yaml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: stocks-ui-secrets
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  backendType: gcpSecretsManager
+  projectId: corded-imagery-343815
+  data:
+    - name: PORT
+      key: pluto-stocks-ui-secrets
+      property: PORT
+      version: latest
+  template:
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: 'stocks-ui'
+    type: Opaque

--- a/config-root/namespaces/jx-staging/stocks-ui/stocks-ui-stocks-ui-deploy.yaml
+++ b/config-root/namespaces/jx-staging/stocks-ui/stocks-ui-stocks-ui-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: stocks-ui-stocks-ui
   labels:
     draft: draft-app
-    chart: "stocks-ui-0.0.7"
+    chart: "stocks-ui-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'stocks-ui'
@@ -25,11 +25,13 @@ spec:
       serviceAccountName: stocks-ui-stocks-ui
       containers:
         - name: stocks-ui
-          image: "gcr.io/corded-imagery-343815/stocks-ui:0.0.7"
+          image: "gcr.io/corded-imagery-343815/stocks-ui:0.0.8"
           imagePullPolicy: IfNotPresent
           env:
+            - name: PORT
+              value: 3002
             - name: VERSION
-              value: 0.0.7
+              value: 0.0.8
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/stocks-ui/stocks-ui-svc.yaml
+++ b/config-root/namespaces/jx-staging/stocks-ui/stocks-ui-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: stocks-ui
   labels:
-    chart: "stocks-ui-0.0.7"
+    chart: "stocks-ui-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'stocks-ui'

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> stocks-ui </a></td>
-	      <td>0.0.7</td>
+	      <td>0.0.8</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -103,17 +103,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
   - apiVersion: v1
-    appVersion: 0.0.7
+    appVersion: 0.0.8
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-09T03:05:07Z"
+    firstDeployed: "2022-04-09T11:53:27Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-09T03:05:07Z"
+    lastDeployed: "2022-04-09T11:53:27Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fstocks-ui&dateRangeUnbound=both
     name: stocks-ui
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/stocks-ui
-    version: 0.0.7
+    version: 0.0.8
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -30,7 +30,7 @@ releases:
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
 - chart: dev/stocks-ui
-  version: 0.0.7
+  version: 0.0.8
   name: stocks-ui
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote stocks-ui to version 0.0.8

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
