### PR TITLE
chore: promote stocks-ui to version 0.0.8

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-agjow-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-agjow-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-whbde
+  name: jx-verify-gc-jobs-agjow
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-933uq
+    app: jx-verify-gc-jobs-p1qxx
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-j49j6-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-j49j6-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-4nxk3
+  name: jx-verify-gc-jobs-j49j6
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-ingress.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-ingress.yaml
@@ -1,0 +1,26 @@
+# Source: stocks-ui/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'stocks-ui'
+  name: stocks-ui
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: stocks-ui
+                port:
+                  number: 3002
+      host: stocks-ui.binomy.io
+  tls:
+    - hosts:
+        - stocks-ui.binomy.io
+      secretName: "tls-binomy-io-p"

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-secrets-secret.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-secrets-secret.yaml
@@ -1,0 +1,21 @@
+# Source: stocks-ui/templates/secrets.yaml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: stocks-ui-secrets
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  backendType: gcpSecretsManager
+  projectId: corded-imagery-343815
+  data:
+    - name: PORT
+      key: pluto-stocks-ui-secrets
+      property: PORT
+      version: latest
+  template:
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: 'stocks-ui'
+    type: Opaque

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-stocks-ui-deploy.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-stocks-ui-deploy.yaml
@@ -1,0 +1,62 @@
+# Source: stocks-ui/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stocks-ui-stocks-ui
+  labels:
+    draft: draft-app
+    chart: "stocks-ui-0.0.8"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'stocks-ui'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: stocks-ui-stocks-ui
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: stocks-ui-stocks-ui
+    spec:
+      serviceAccountName: stocks-ui-stocks-ui
+      containers:
+        - name: stocks-ui
+          image: "gcr.io/corded-imagery-343815/stocks-ui:0.0.8"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: 3002
+            - name: VERSION
+              value: 0.0.8
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 3002
+          livenessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3002
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3002
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-stocks-ui-sa.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-stocks-ui-sa.yaml
@@ -1,0 +1,10 @@
+# Source: stocks-ui/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stocks-ui-stocks-ui
+  annotations:
+    meta.helm.sh/release-name: 'stocks-ui'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/stocks-ui/stocks-ui-svc.yaml
+++ b/config-root/namespaces/jx-production/stocks-ui/stocks-ui-svc.yaml
@@ -1,0 +1,20 @@
+# Source: stocks-ui/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: stocks-ui
+  labels:
+    chart: "stocks-ui-0.0.8"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'stocks-ui'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3002
+      targetPort: 3002
+      protocol: TCP
+      name: http
+  selector:
+    app: stocks-ui-stocks-ui

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-9tx8a-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-9tx8a-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-muh4w
+  name: jx-verify-gc-jobs-9tx8a
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-m1zgl
+    app: jx-verify-gc-jobs-qnvxg
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-wyubm-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-wyubm-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-klayd
+  name: jx-verify-gc-jobs-wyubm
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,12 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> stocks-ui </a></td>
+	      <td>0.0.8</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -63,6 +63,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
+  - apiVersion: v1
+    appVersion: 0.0.8
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-04-09T11:53:21Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-04-09T11:53:21Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fstocks-ui&dateRangeUnbound=both
+    name: stocks-ui
+    repositoryName: dev
+    repositoryUrl: https://chartmuseum.pluto.binomy.io
+    resourcePath: config-root/namespaces/jx-production/stocks-ui
+    version: 0.0.8
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -33,5 +33,7 @@ releases:
   version: 0.0.8
   name: stocks-ui
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -29,5 +29,9 @@ releases:
   - jx-values.yaml
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
+- chart: dev/stocks-ui
+  version: 0.0.8
+  name: stocks-ui
+  namespace: jx-production
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote stocks-ui to version 0.0.8

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
