### PR TITLE
chore: promote unocoins to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-85vox-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-85vox-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-wvnwz
+  name: jx-verify-gc-jobs-85vox
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-1szlj
+    app: jx-verify-gc-jobs-erwll
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-ehvxd-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-ehvxd-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-qfjwc
+  name: jx-verify-gc-jobs-ehvxd
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-6cbsa-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-6cbsa-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-wsj0k
+  name: jx-verify-gc-jobs-6cbsa
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-nwjbd
+    app: jx-verify-gc-jobs-ttyvi
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-vkwmc-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-vkwmc-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-goc75
+  name: jx-verify-gc-jobs-vkwmc
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-ingress.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-ingress.yaml
@@ -18,7 +18,7 @@ spec:
               service:
                 name: unocoins
                 port:
-                  number: 80
+                  number: 3002
       host: unocoins.staging.binomy.io
   tls:
     - hosts:

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: unocoins
   labels:
-    chart: "unocoins-0.0.3"
+    chart: "unocoins-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'
@@ -12,8 +12,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 80
-      targetPort: 8080
+    - port: 3002
+      targetPort: 3002
       protocol: TCP
       name: http
   selector:

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: unocoins-unocoins
   labels:
     draft: draft-app
-    chart: "unocoins-0.0.3"
+    chart: "unocoins-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'
@@ -25,21 +25,21 @@ spec:
       serviceAccountName: unocoins-unocoins
       containers:
         - name: unocoins
-          image: "gcr.io/corded-imagery-343815/unocoins:0.0.3"
+          image: "gcr.io/corded-imagery-343815/unocoins:0.0.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT
               value: "3002"
             - name: VERSION
-              value: 0.0.3
+              value: 0.0.4
           envFrom: null
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 3002
           livenessProbe:
             httpGet:
               path: /_healthcheck
-              port: 8080
+              port: 3002
             initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
@@ -47,7 +47,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /_healthcheck
-              port: 8080
+              port: 3002
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
-	      <td>0.0.3</td>
+	      <td>0.0.4</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -115,17 +115,17 @@
     resourcePath: config-root/namespaces/jx-staging/stocks-ui
     version: 0.0.10
   - apiVersion: v1
-    appVersion: 0.0.3
+    appVersion: 0.0.4
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-10T03:43:08Z"
+    firstDeployed: "2022-04-10T03:57:29Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-10T03:43:08Z"
+    lastDeployed: "2022-04-10T03:57:29Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
     name: unocoins
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/unocoins
-    version: 0.0.3
+    version: 0.0.4
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -36,7 +36,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/unocoins
-  version: 0.0.3
+  version: 0.0.4
   name: unocoins
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote unocoins to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
