### PR TITLE
chore: promote unocoins to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-bokvq-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-bokvq-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-qfjwc
+  name: jx-verify-gc-jobs-bokvq
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-xbdkd-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-xbdkd-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-wvnwz
+  name: jx-verify-gc-jobs-xbdkd
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-1szlj
+    app: jx-verify-gc-jobs-iuay4
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/unocoins/unocoins-ingress.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-ingress.yaml
@@ -1,0 +1,26 @@
+# Source: unocoins/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'unocoins'
+  name: unocoins
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: unocoins
+                port:
+                  number: 3002
+      host: unocoins.binomy.io
+  tls:
+    - hosts:
+        - unocoins.binomy.io
+      secretName: "tls-binomy-io-p"

--- a/config-root/namespaces/jx-production/unocoins/unocoins-svc.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-svc.yaml
@@ -1,0 +1,20 @@
+# Source: unocoins/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: unocoins
+  labels:
+    chart: "unocoins-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'unocoins'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3002
+      targetPort: 3002
+      protocol: TCP
+      name: http
+  selector:
+    app: unocoins-unocoins

--- a/config-root/namespaces/jx-production/unocoins/unocoins-unocoins-deploy.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-unocoins-deploy.yaml
@@ -1,0 +1,62 @@
+# Source: unocoins/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unocoins-unocoins
+  labels:
+    draft: draft-app
+    chart: "unocoins-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'unocoins'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: unocoins-unocoins
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: unocoins-unocoins
+    spec:
+      serviceAccountName: unocoins-unocoins
+      containers:
+        - name: unocoins
+          image: "gcr.io/corded-imagery-343815/unocoins:0.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: "3002"
+            - name: VERSION
+              value: 0.0.4
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 3002
+          livenessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3002
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3002
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/unocoins/unocoins-unocoins-sa.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-unocoins-sa.yaml
@@ -1,0 +1,10 @@
+# Source: unocoins/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: unocoins-unocoins
+  annotations:
+    meta.helm.sh/release-name: 'unocoins'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-arx1s-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-arx1s-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-goc75
+  name: jx-verify-gc-jobs-arx1s
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-oz1zr-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-oz1zr-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-wsj0k
+  name: jx-verify-gc-jobs-oz1zr
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-nwjbd
+    app: jx-verify-gc-jobs-ayzid
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,12 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
+	      <td>0.0.4</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -63,6 +63,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
+  - apiVersion: v1
+    appVersion: 0.0.4
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-04-10T03:57:41Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-04-10T03:57:41Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
+    name: unocoins
+    repositoryName: dev
+    repositoryUrl: https://chartmuseum.pluto.binomy.io
+    resourcePath: config-root/namespaces/jx-production/unocoins
+    version: 0.0.4
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -29,5 +29,9 @@ releases:
   - jx-values.yaml
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
+- chart: dev/unocoins
+  version: 0.0.4
+  name: unocoins
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -33,5 +33,7 @@ releases:
   version: 0.0.4
   name: unocoins
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote unocoins to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
