### PR TITLE
chore: promote unocoins to version 0.0.11

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-ahkef-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-ahkef-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-89dkd
+  name: jx-verify-gc-jobs-ahkef
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-snqof-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-snqof-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-ieip9
+  name: jx-verify-gc-jobs-snqof
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-4be6i
+    app: jx-verify-gc-jobs-4mxoz
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-af7by-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-af7by-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-dppeg
+  name: jx-verify-gc-jobs-af7by
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-laxm9-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-laxm9-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-cg8yp
+  name: jx-verify-gc-jobs-laxm9
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-asajg
+    app: jx-verify-gc-jobs-wxdp5
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-secrets-secret.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-secrets-secret.yaml
@@ -1,0 +1,21 @@
+# Source: unocoins/templates/secrets.yaml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: unocoins-secrets
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  backendType: gcpSecretsManager
+  projectId: corded-imagery-343815
+  data:
+    - name: sa.json
+      key: pluto-unocoins-secrets
+      property: sa.json
+      version: latest
+  template:
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: 'unocoins'
+    type: Opaque

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: unocoins
   labels:
-    chart: "unocoins-0.0.9"
+    chart: "unocoins-0.0.11"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: unocoins-unocoins
   labels:
     draft: draft-app
-    chart: "unocoins-0.0.9"
+    chart: "unocoins-0.0.11"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'
@@ -25,13 +25,13 @@ spec:
       serviceAccountName: unocoins-unocoins
       containers:
         - name: unocoins
-          image: "gcr.io/corded-imagery-343815/unocoins:0.0.9"
+          image: "gcr.io/corded-imagery-343815/unocoins:0.0.11"
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT
               value: "3002"
             - name: VERSION
-              value: 0.0.9
+              value: 0.0.11
           envFrom: null
           ports:
             - name: http

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
-	      <td>0.0.9</td>
+	      <td>0.0.11</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -103,17 +103,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
   - apiVersion: v1
-    appVersion: 0.0.9
+    appVersion: 0.0.11
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-13T09:32:30Z"
+    firstDeployed: "2022-04-13T13:46:54Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-13T09:32:30Z"
+    lastDeployed: "2022-04-13T13:46:54Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
     name: unocoins
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/unocoins
-    version: 0.0.9
+    version: 0.0.11
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -30,7 +30,7 @@ releases:
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
 - chart: dev/unocoins
-  version: 0.0.9
+  version: 0.0.11
   name: unocoins
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote unocoins to version 0.0.11

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
