### PR TITLE
chore: promote unocoins to version 0.0.13

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-iizcs-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-iizcs-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-vxw7a
+  name: jx-verify-gc-jobs-iizcs
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-luoss
+    app: jx-verify-gc-jobs-vcywa
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-xt0tz-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-xt0tz-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-lipvp
+  name: jx-verify-gc-jobs-xt0tz
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-l3jbv-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-l3jbv-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-7frny
+  name: jx-verify-gc-jobs-l3jbv
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-mkzcw-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-mkzcw-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-npnhd
+  name: jx-verify-gc-jobs-mkzcw
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-d6e9y
+    app: jx-verify-gc-jobs-meosm
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-secrets-secret.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-secrets-secret.yaml
@@ -14,6 +14,78 @@ spec:
       key: pluto-unocoins-secrets
       property: sa.json
       version: latest
+    - name: BQ_PROJECT_ID
+      key: pluto-unocoins-secrets
+      property: BQ_PROJECT_ID
+      version: latest
+    - name: BQ_YF_DATASET_NAME
+      key: pluto-unocoins-secrets
+      property: BQ_YF_DATASET_NAME
+      version: latest
+    - name: BQ_IEX_DATASET_NAME
+      key: pluto-unocoins-secrets
+      property: BQ_IEX_DATASET_NAME
+      version: latest
+    - name: BQ_YF_HISTORICALS_TABLENAME
+      key: pluto-unocoins-secrets
+      property: BQ_YF_HISTORICALS_TABLENAME
+      version: latest
+    - name: BQ_SYMBOLMAP
+      key: pluto-unocoins-secrets
+      property: BQ_SYMBOLMAP
+      version: latest
+    - name: BQ_EXCHANGES_TABLE
+      key: pluto-unocoins-secrets
+      property: BQ_EXCHANGES_TABLE
+      version: latest
+    - name: BQ_IEX_SYMBOLS
+      key: pluto-unocoins-secrets
+      property: BQ_IEX_SYMBOLS
+      version: latest
+    - name: SYMBOLS_DB
+      key: pluto-unocoins-secrets
+      property: SYMBOLS_DB
+      version: latest
+    - name: EXCHANGES_DB
+      key: pluto-unocoins-secrets
+      property: EXCHANGES_DB
+      version: latest
+    - name: BQ_CRYPTO_DATASET_NAME
+      key: pluto-unocoins-secrets
+      property: BQ_CRYPTO_DATASET_NAME
+      version: latest
+    - name: BQ_CRYPTO_QUOTES
+      key: pluto-unocoins-secrets
+      property: BQ_CRYPTO_QUOTES
+      version: latest
+    - name: BQ_CRYPTO_SYMBOLS
+      key: pluto-unocoins-secrets
+      property: BQ_CRYPTO_SYMBOLS
+      version: latest
+    - name: EXCHANGES_API
+      key: pluto-unocoins-secrets
+      property: EXCHANGES_API
+      version: latest
+    - name: CRYPTO_API
+      key: pluto-unocoins-secrets
+      property: CRYPTO_API
+      version: latest
+    - name: CRYPTO_METADATA
+      key: pluto-unocoins-secrets
+      property: CRYPTO_METADATA
+      version: latest
+    - name: CRYPTO_PRICES
+      key: pluto-unocoins-secrets
+      property: CRYPTO_PRICES
+      version: latest
+    - name: IEX_INFO
+      key: pluto-unocoins-secrets
+      property: IEX_INFO
+      version: latest
+    - name: YF_INFO
+      key: pluto-unocoins-secrets
+      property: YF_INFO
+      version: latest
   template:
     metadata:
       annotations:

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: unocoins
   labels:
-    chart: "unocoins-0.0.12"
+    chart: "unocoins-0.0.13"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: unocoins-unocoins
   labels:
     draft: draft-app
-    chart: "unocoins-0.0.12"
+    chart: "unocoins-0.0.13"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'
@@ -25,15 +25,100 @@ spec:
       serviceAccountName: unocoins-unocoins
       containers:
         - name: unocoins
-          image: "gcr.io/corded-imagery-343815/unocoins:0.0.12"
+          image: "gcr.io/corded-imagery-343815/unocoins:0.0.13"
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT
               value: "3002"
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
               value: "/var/run/secret/cloud.google.com/sa.json"
+            - name: BQ_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_PROJECT_ID
+            - name: BQ_YF_DATASET_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_YF_DATASET_NAME
+            - name: BQ_IEX_DATASET_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_IEX_DATASET_NAME
+            - name: BQ_YF_HISTORICALS_TABLENAME
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_YF_HISTORICALS_TABLENAME
+            - name: BQ_SYMBOLMAP
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_SYMBOLMAP
+            - name: BQ_EXCHANGES_TABLE
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_EXCHANGES_TABLE
+            - name: BQ_IEX_SYMBOLS
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_IEX_SYMBOLS
+            - name: SYMBOLS_DB
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: SYMBOLS_DB
+            - name: EXCHANGES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: EXCHANGES_DB
+            - name: BQ_CRYPTO_DATASET_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_CRYPTO_DATASET_NAME
+            - name: BQ_CRYPTO_QUOTES
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_CRYPTO_QUOTES
+            - name: BQ_CRYPTO_SYMBOLS
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_CRYPTO_SYMBOLS
+            - name: EXCHANGES_API
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: EXCHANGES_API
+            - name: CRYPTO_API
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: CRYPTO_API
+            - name: CRYPTO_METADATA
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: CRYPTO_METADATA
+            - name: CRYPTO_PRICES
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: CRYPTO_PRICES
+            - name: IEX_INFO
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: IEX_INFO
             - name: VERSION
-              value: 0.0.12
+              value: 0.0.13
           volumeMounts:
             - name: "service-account"
               mountPath: "/var/run/secret/cloud.google.com"

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
-	      <td>0.0.12</td>
+	      <td>0.0.13</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -103,17 +103,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
   - apiVersion: v1
-    appVersion: 0.0.12
+    appVersion: 0.0.13
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-13T14:17:34Z"
+    firstDeployed: "2022-04-13T14:46:24Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-13T14:17:34Z"
+    lastDeployed: "2022-04-13T14:46:24Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
     name: unocoins
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/unocoins
-    version: 0.0.12
+    version: 0.0.13
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -30,7 +30,7 @@ releases:
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
 - chart: dev/unocoins
-  version: 0.0.12
+  version: 0.0.13
   name: unocoins
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote unocoins to version 0.0.13

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
