### PR TITLE
chore: promote unocoins to version 0.0.15

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-pgwjp-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-pgwjp-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-xjuyv
+  name: jx-verify-gc-jobs-pgwjp
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-sqhln
+    app: jx-verify-gc-jobs-d4dpw
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-vahgm-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-vahgm-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-wbio2
+  name: jx-verify-gc-jobs-vahgm
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-staging
+  namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-rbpbf-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-rbpbf-rb.yaml
@@ -2,10 +2,10 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-fykti
+  name: jx-verify-gc-jobs-rbpbf
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
-  namespace: jx-production
+  namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
 roleRef:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-sxcgj-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-sxcgj-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-qag77
+  name: jx-verify-gc-jobs-sxcgj
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-kq75s
+    app: jx-verify-gc-jobs-oqm9k
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-secrets-secret.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-secrets-secret.yaml
@@ -10,10 +10,6 @@ spec:
   backendType: gcpSecretsManager
   projectId: corded-imagery-343815
   data:
-    - name: sa.json
-      key: pluto-unocoins-secrets
-      property: sa.json
-      version: latest
     - name: BQ_PROJECT_ID
       key: pluto-unocoins-secrets
       property: BQ_PROJECT_ID

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: unocoins
   labels:
-    chart: "unocoins-0.0.14"
+    chart: "unocoins-0.0.15"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: unocoins-unocoins
   labels:
     draft: draft-app
-    chart: "unocoins-0.0.14"
+    chart: "unocoins-0.0.15"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'
@@ -25,13 +25,11 @@ spec:
       serviceAccountName: bigquery-sa
       containers:
         - name: unocoins
-          image: "gcr.io/corded-imagery-343815/unocoins:0.0.14"
+          image: "gcr.io/corded-imagery-343815/unocoins:0.0.15"
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT
               value: "3002"
-            - name: "GOOGLE_APPLICATION_CREDENTIALS"
-              value: "/var/run/secret/cloud.google.com/sa.json"
             - name: BQ_PROJECT_ID
               valueFrom:
                 secretKeyRef:
@@ -118,7 +116,7 @@ spec:
                   name: unocoins-secrets
                   key: IEX_INFO
             - name: VERSION
-              value: 0.0.14
+              value: 0.0.15
           volumeMounts:
             - name: "service-account"
               mountPath: "/var/run/secret/cloud.google.com"

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
-	      <td>0.0.14</td>
+	      <td>0.0.15</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -103,17 +103,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
   - apiVersion: v1
-    appVersion: 0.0.14
+    appVersion: 0.0.15
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-14T02:46:02Z"
+    firstDeployed: "2022-04-14T03:05:44Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-14T02:46:02Z"
+    lastDeployed: "2022-04-14T03:05:44Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
     name: unocoins
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/unocoins
-    version: 0.0.14
+    version: 0.0.15
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -30,7 +30,7 @@ releases:
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
 - chart: dev/unocoins
-  version: 0.0.14
+  version: 0.0.15
   name: unocoins
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote unocoins to version 0.0.15

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
