### PR TITLE
chore: promote unocoins to version 0.0.16

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-0npnq-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-0npnq-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-kxf5j
+  name: jx-verify-gc-jobs-0npnq
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-4jwlo
+    app: jx-verify-gc-jobs-nw6tk
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-yyzet-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-yyzet-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-0xqez
+  name: jx-verify-gc-jobs-yyzet
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/unocoins/bigquery-sa-sa.yaml
+++ b/config-root/namespaces/jx-production/unocoins/bigquery-sa-sa.yaml
@@ -1,0 +1,11 @@
+# Source: unocoins/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bigquery-sa
+  annotations:
+    iam.gke.io/gcp-service-account: bigquery@corded-imagery-343815.iam.gserviceaccount.com
+    meta.helm.sh/release-name: 'unocoins'
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/unocoins/unocoins-ingress.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-ingress.yaml
@@ -1,0 +1,26 @@
+# Source: unocoins/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'unocoins'
+  name: unocoins
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: unocoins
+                port:
+                  number: 3002
+      host: unocoins.binomy.io
+  tls:
+    - hosts:
+        - unocoins.binomy.io
+      secretName: "tls-binomy-io-p"

--- a/config-root/namespaces/jx-production/unocoins/unocoins-secrets-secret.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-secrets-secret.yaml
@@ -1,0 +1,89 @@
+# Source: unocoins/templates/secrets.yaml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: unocoins-secrets
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  backendType: gcpSecretsManager
+  projectId: corded-imagery-343815
+  data:
+    - name: BQ_PROJECT_ID
+      key: pluto-unocoins-secrets
+      property: BQ_PROJECT_ID
+      version: latest
+    - name: BQ_YF_DATASET_NAME
+      key: pluto-unocoins-secrets
+      property: BQ_YF_DATASET_NAME
+      version: latest
+    - name: BQ_IEX_DATASET_NAME
+      key: pluto-unocoins-secrets
+      property: BQ_IEX_DATASET_NAME
+      version: latest
+    - name: BQ_YF_HISTORICALS_TABLENAME
+      key: pluto-unocoins-secrets
+      property: BQ_YF_HISTORICALS_TABLENAME
+      version: latest
+    - name: BQ_SYMBOLMAP
+      key: pluto-unocoins-secrets
+      property: BQ_SYMBOLMAP
+      version: latest
+    - name: BQ_EXCHANGES_TABLE
+      key: pluto-unocoins-secrets
+      property: BQ_EXCHANGES_TABLE
+      version: latest
+    - name: BQ_IEX_SYMBOLS
+      key: pluto-unocoins-secrets
+      property: BQ_IEX_SYMBOLS
+      version: latest
+    - name: SYMBOLS_DB
+      key: pluto-unocoins-secrets
+      property: SYMBOLS_DB
+      version: latest
+    - name: EXCHANGES_DB
+      key: pluto-unocoins-secrets
+      property: EXCHANGES_DB
+      version: latest
+    - name: BQ_CRYPTO_DATASET_NAME
+      key: pluto-unocoins-secrets
+      property: BQ_CRYPTO_DATASET_NAME
+      version: latest
+    - name: BQ_CRYPTO_QUOTES
+      key: pluto-unocoins-secrets
+      property: BQ_CRYPTO_QUOTES
+      version: latest
+    - name: BQ_CRYPTO_SYMBOLS
+      key: pluto-unocoins-secrets
+      property: BQ_CRYPTO_SYMBOLS
+      version: latest
+    - name: EXCHANGES_API
+      key: pluto-unocoins-secrets
+      property: EXCHANGES_API
+      version: latest
+    - name: CRYPTO_API
+      key: pluto-unocoins-secrets
+      property: CRYPTO_API
+      version: latest
+    - name: CRYPTO_METADATA
+      key: pluto-unocoins-secrets
+      property: CRYPTO_METADATA
+      version: latest
+    - name: CRYPTO_PRICES
+      key: pluto-unocoins-secrets
+      property: CRYPTO_PRICES
+      version: latest
+    - name: IEX_INFO
+      key: pluto-unocoins-secrets
+      property: IEX_INFO
+      version: latest
+    - name: YF_INFO
+      key: pluto-unocoins-secrets
+      property: YF_INFO
+      version: latest
+  template:
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: 'unocoins'
+    type: Opaque

--- a/config-root/namespaces/jx-production/unocoins/unocoins-svc.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-svc.yaml
@@ -1,0 +1,20 @@
+# Source: unocoins/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: unocoins
+  labels:
+    chart: "unocoins-0.0.16"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'unocoins'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3002
+      targetPort: 3002
+      protocol: TCP
+      name: http
+  selector:
+    app: unocoins-unocoins

--- a/config-root/namespaces/jx-production/unocoins/unocoins-unocoins-deploy.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-unocoins-deploy.yaml
@@ -1,0 +1,147 @@
+# Source: unocoins/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unocoins-unocoins
+  labels:
+    draft: draft-app
+    chart: "unocoins-0.0.16"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'unocoins'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-production
+spec:
+  selector:
+    matchLabels:
+      app: unocoins-unocoins
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: unocoins-unocoins
+    spec:
+      serviceAccountName: bigquery-sa
+      containers:
+        - name: unocoins
+          image: "gcr.io/corded-imagery-343815/unocoins:0.0.16"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: "3002"
+            - name: BQ_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_PROJECT_ID
+            - name: BQ_YF_DATASET_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_YF_DATASET_NAME
+            - name: BQ_IEX_DATASET_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_IEX_DATASET_NAME
+            - name: BQ_YF_HISTORICALS_TABLENAME
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_YF_HISTORICALS_TABLENAME
+            - name: BQ_SYMBOLMAP
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_SYMBOLMAP
+            - name: BQ_EXCHANGES_TABLE
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_EXCHANGES_TABLE
+            - name: BQ_IEX_SYMBOLS
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_IEX_SYMBOLS
+            - name: SYMBOLS_DB
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: SYMBOLS_DB
+            - name: EXCHANGES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: EXCHANGES_DB
+            - name: BQ_CRYPTO_DATASET_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_CRYPTO_DATASET_NAME
+            - name: BQ_CRYPTO_QUOTES
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_CRYPTO_QUOTES
+            - name: BQ_CRYPTO_SYMBOLS
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: BQ_CRYPTO_SYMBOLS
+            - name: EXCHANGES_API
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: EXCHANGES_API
+            - name: CRYPTO_API
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: CRYPTO_API
+            - name: CRYPTO_METADATA
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: CRYPTO_METADATA
+            - name: CRYPTO_PRICES
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: CRYPTO_PRICES
+            - name: IEX_INFO
+              valueFrom:
+                secretKeyRef:
+                  name: unocoins-secrets
+                  key: IEX_INFO
+            - name: VERSION
+              value: 0.0.16
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 3002
+          livenessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3002
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /_healthcheck
+              port: 3002
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-9iygg-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-9iygg-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-kofau
+  name: jx-verify-gc-jobs-9iygg
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-zkfit
+    app: jx-verify-gc-jobs-5kc73
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-wi43j-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-wi43j-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-ykakh
+  name: jx-verify-gc-jobs-wi43j
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,12 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
+	      <td>0.0.16</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -63,6 +63,18 @@
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
+  - apiVersion: v1
+    appVersion: 0.0.16
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-04-14T03:20:56Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-04-14T03:20:56Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
+    name: unocoins
+    repositoryName: dev
+    repositoryUrl: https://chartmuseum.pluto.binomy.io
+    resourcePath: config-root/namespaces/jx-production/unocoins
+    version: 0.0.16
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -33,5 +33,7 @@ releases:
   version: 0.0.16
   name: unocoins
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -29,5 +29,9 @@ releases:
   - jx-values.yaml
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
+- chart: dev/unocoins
+  version: 0.0.16
+  name: unocoins
+  namespace: jx-production
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote unocoins to version 0.0.16

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
