### PR TITLE
chore: promote unocoins to version 0.0.20

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-fszsf-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-fszsf-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-pqhfx
+  name: jx-verify-gc-jobs-fszsf
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-isyn8
+    app: jx-verify-gc-jobs-obekz
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-m0lcq-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-m0lcq-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-bwkpa
+  name: jx-verify-gc-jobs-m0lcq
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/unocoins/unocoins-svc.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: unocoins
   labels:
-    chart: "unocoins-0.0.17"
+    chart: "unocoins-0.0.20"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'

--- a/config-root/namespaces/jx-production/unocoins/unocoins-unocoins-deploy.yaml
+++ b/config-root/namespaces/jx-production/unocoins/unocoins-unocoins-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: unocoins-unocoins
   labels:
     draft: draft-app
-    chart: "unocoins-0.0.17"
+    chart: "unocoins-0.0.20"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: bigquery-sa
       containers:
         - name: unocoins
-          image: "gcr.io/corded-imagery-343815/unocoins:0.0.17"
+          image: "gcr.io/corded-imagery-343815/unocoins:0.0.20"
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT
@@ -116,7 +116,7 @@ spec:
                   name: unocoins-secrets
                   key: IEX_INFO
             - name: VERSION
-              value: 0.0.17
+              value: 0.0.20
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-wukkc-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-wukkc-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-hu0bo
+  name: jx-verify-gc-jobs-wukkc
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-xtdnv-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-xtdnv-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-3ck0d
+  name: jx-verify-gc-jobs-xtdnv
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-t0rls
+    app: jx-verify-gc-jobs-nesec
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
-	      <td>0.0.17</td>
+	      <td>0.0.20</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -64,17 +64,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
   - apiVersion: v1
-    appVersion: 0.0.17
+    appVersion: 0.0.20
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-14T06:08:29Z"
+    firstDeployed: "2022-04-19T04:49:20Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-14T06:08:29Z"
+    lastDeployed: "2022-04-19T04:49:20Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
     name: unocoins
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-production/unocoins
-    version: 0.0.17
+    version: 0.0.20
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -30,7 +30,7 @@ releases:
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
 - chart: dev/unocoins
-  version: 0.0.17
+  version: 0.0.20
   name: unocoins
   namespace: jx-production
   values:


### PR DESCRIPTION
chore: promote unocoins to version 0.0.20

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
