### PR TITLE
chore: promote origins-cms to version 0.0.24

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-a2tsm-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-a2tsm-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-kvibl
+  name: jx-verify-gc-jobs-a2tsm
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-hvxr3
+    app: jx-verify-gc-jobs-wbbje
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-kljh6-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-kljh6-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-bo22g
+  name: jx-verify-gc-jobs-kljh6
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-deploy.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: origins-cms-origins-cms
   labels:
     draft: draft-app
-    chart: "origins-cms-0.0.20"
+    chart: "origins-cms-0.0.24"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: origins-cms-origins-cms
       containers:
         - name: origins-cms
-          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.20"
+          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.24"
           imagePullPolicy: IfNotPresent
           env:
             - name: SESSION_SECRET
@@ -59,7 +59,7 @@ spec:
                   name: origins-cms-secrets
                   key: CLOUDINARY_API_FOLDER
             - name: VERSION
-              value: 0.0.20
+              value: 0.0.24
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-svc.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: origins-cms
   labels:
-    chart: "origins-cms-0.0.20"
+    chart: "origins-cms-0.0.24"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-febba-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-febba-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-l8zvv
+  name: jx-verify-gc-jobs-febba
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-s8dpg
+    app: jx-verify-gc-jobs-mivzx
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-vrgnh-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-vrgnh-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-ldkfw
+  name: jx-verify-gc-jobs-vrgnh
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
-	      <td>0.0.20</td>
+	      <td>0.0.24</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -41,17 +41,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
   - apiVersion: v1
-    appVersion: 0.0.20
+    appVersion: 0.0.24
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-08T15:30:46Z"
+    firstDeployed: "2022-04-21T05:31:09Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-08T15:30:46Z"
+    lastDeployed: "2022-04-21T05:31:09Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
     name: origins-cms
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-production/origins-cms
-    version: 0.0.20
+    version: 0.0.24
   - apiVersion: v1
     appVersion: 0.0.24
     description: Acme

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/origins-cms
-  version: 0.0.20
+  version: 0.0.24
   name: origins-cms
   namespace: jx-production
   values:


### PR DESCRIPTION
chore: promote origins-cms to version 0.0.24

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
