### PR TITLE
chore: promote unocoins to version 0.0.21

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-ix9ml-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-ix9ml-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-nhgbl
+  name: jx-verify-gc-jobs-ix9ml
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-xvwnz
+    app: jx-verify-gc-jobs-rnex9
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-rsv5o-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-rsv5o-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-qoxiy
+  name: jx-verify-gc-jobs-rsv5o
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-8gh97-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-8gh97-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-6t4zy
+  name: jx-verify-gc-jobs-8gh97
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-tfvzu
+    app: jx-verify-gc-jobs-v0euf
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-aifyu-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-aifyu-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-e8m5u
+  name: jx-verify-gc-jobs-aifyu
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: unocoins
   labels:
-    chart: "unocoins-0.0.20"
+    chart: "unocoins-0.0.21"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'

--- a/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
+++ b/config-root/namespaces/jx-staging/unocoins/unocoins-unocoins-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: unocoins-unocoins
   labels:
     draft: draft-app
-    chart: "unocoins-0.0.20"
+    chart: "unocoins-0.0.21"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'unocoins'
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: bigquery-sa
       containers:
         - name: unocoins
-          image: "gcr.io/corded-imagery-343815/unocoins:0.0.20"
+          image: "gcr.io/corded-imagery-343815/unocoins:0.0.21"
           imagePullPolicy: IfNotPresent
           env:
             - name: PORT
@@ -116,7 +116,7 @@ spec:
                   name: unocoins-secrets
                   key: IEX_INFO
             - name: VERSION
-              value: 0.0.20
+              value: 0.0.21
           envFrom: null
           ports:
             - name: http

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
-	      <td>0.0.20</td>
+	      <td>0.0.21</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -115,17 +115,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
   - apiVersion: v1
-    appVersion: 0.0.20
+    appVersion: 0.0.21
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-19T03:48:40Z"
+    firstDeployed: "2022-04-25T06:09:24Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-19T03:48:40Z"
+    lastDeployed: "2022-04-25T06:09:24Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
     name: unocoins
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/unocoins
-    version: 0.0.20
+    version: 0.0.21
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -30,7 +30,7 @@ releases:
   - acme-values.yaml
   - ../../versionStream/charts/jxgh/acme-jx/values.yaml.gotmpl
 - chart: dev/unocoins
-  version: 0.0.20
+  version: 0.0.21
   name: unocoins
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote unocoins to version 0.0.21

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
