### PR TITLE
chore: promote origins-cms to version 0.1.0

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-hijiz-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-hijiz-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-kditv
+  name: jx-verify-gc-jobs-hijiz
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-uuwkv
+    app: jx-verify-gc-jobs-x156a
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1
@@ -25,7 +25,7 @@ spec:
           env:
             - name: XDG_CONFIG_HOME
               value: /home
-          image: ghcr.io/jenkins-x/jx-verify:0.2.3
+          image: ghcr.io/jenkins-x/jx-verify:0.2.5
           imagePullPolicy: IfNotPresent
           name: job
       dnsPolicy: ClusterFirst

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-idb2d-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-idb2d-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-kl91c
+  name: jx-verify-gc-jobs-idb2d
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-dq1i2-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-dq1i2-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-uei5d
+  name: jx-verify-gc-jobs-dq1i2
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-co8os
+    app: jx-verify-gc-jobs-hkxi9
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1
@@ -25,7 +25,7 @@ spec:
           env:
             - name: XDG_CONFIG_HOME
               value: /home
-          image: ghcr.io/jenkins-x/jx-verify:0.2.3
+          image: ghcr.io/jenkins-x/jx-verify:0.2.5
           imagePullPolicy: IfNotPresent
           name: job
       dnsPolicy: ClusterFirst

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-xp8yh-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-xp8yh-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-p1vwl
+  name: jx-verify-gc-jobs-xp8yh
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-deploy.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: origins-cms-origins-cms
   labels:
     draft: draft-app
-    chart: "origins-cms-0.0.27"
+    chart: "origins-cms-0.1.0"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: origins-cms-origins-cms
       containers:
         - name: origins-cms
-          image: "gcr.io/corded-imagery-343815/origins-cms:0.0.27"
+          image: "gcr.io/corded-imagery-343815/origins-cms:0.1.0"
           imagePullPolicy: IfNotPresent
           env:
             - name: SESSION_SECRET
@@ -59,7 +59,7 @@ spec:
                   name: origins-cms-secrets
                   key: CLOUDINARY_API_FOLDER
             - name: VERSION
-              value: 0.0.27
+              value: 0.1.0
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-svc.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: origins-cms
   labels:
-    chart: "origins-cms-0.0.27"
+    chart: "origins-cms-0.1.0"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
-	      <td>0.0.27</td>
+	      <td>0.1.0</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -92,17 +92,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
   - apiVersion: v1
-    appVersion: 0.0.27
+    appVersion: 0.1.0
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-04-24T07:22:40Z"
+    firstDeployed: "2022-05-02T10:45:32Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-04-24T07:22:40Z"
+    lastDeployed: "2022-05-02T10:45:32Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
     name: origins-cms
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/origins-cms
-    version: 0.0.27
+    version: 0.1.0
   - apiVersion: v1
     appVersion: 0.0.24
     description: Acme

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/origins-cms
-  version: 0.0.27
+  version: 0.1.0
   name: origins-cms
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote origins-cms to version 0.1.0

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
