### PR TITLE
chore: promote origins-cms to version 0.1.1

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-gqi6h-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-gqi6h-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-dq1i2
+  name: jx-verify-gc-jobs-gqi6h
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-hkxi9
+    app: jx-verify-gc-jobs-au9q6
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1
@@ -25,7 +25,7 @@ spec:
           env:
             - name: XDG_CONFIG_HOME
               value: /home
-          image: ghcr.io/jenkins-x/jx-verify:0.2.5
+          image: ghcr.io/jenkins-x/jx-verify:0.2.6
           imagePullPolicy: IfNotPresent
           name: job
       dnsPolicy: ClusterFirst

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-roppk-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-roppk-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-idb2d
+  name: jx-verify-gc-jobs-roppk
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-6tyit-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-6tyit-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-xp8yh
+  name: jx-verify-gc-jobs-6tyit
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-hwxc0-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-hwxc0-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-hijiz
+  name: jx-verify-gc-jobs-hwxc0
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-x156a
+    app: jx-verify-gc-jobs-gxvt5
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1
@@ -25,7 +25,7 @@ spec:
           env:
             - name: XDG_CONFIG_HOME
               value: /home
-          image: ghcr.io/jenkins-x/jx-verify:0.2.5
+          image: ghcr.io/jenkins-x/jx-verify:0.2.6
           imagePullPolicy: IfNotPresent
           name: job
       dnsPolicy: ClusterFirst

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-deploy.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-origins-cms-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: origins-cms-origins-cms
   labels:
     draft: draft-app
-    chart: "origins-cms-0.1.0"
+    chart: "origins-cms-0.1.1"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: origins-cms-origins-cms
       containers:
         - name: origins-cms
-          image: "gcr.io/corded-imagery-343815/origins-cms:0.1.0"
+          image: "gcr.io/corded-imagery-343815/origins-cms:0.1.1"
           imagePullPolicy: IfNotPresent
           env:
             - name: SESSION_SECRET
@@ -48,18 +48,43 @@ spec:
                 secretKeyRef:
                   name: origins-cms-secrets
                   key: CLOUDINARY_API_KEY
-            - name: CLOUDINARY_API_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: origins-cms-secrets
-                  key: CLOUDINARY_API_SECRET
             - name: CLOUDINARY_API_FOLDER
               valueFrom:
                 secretKeyRef:
                   name: origins-cms-secrets
                   key: CLOUDINARY_API_FOLDER
+            - name: MAIL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: MAIL_PASSWORD
+            - name: MAIL_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: MAIL_HOST
+            - name: MAIL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: MAIL_USER
+            - name: MAIL_SENDER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: MAIL_SENDER_NAME
+            - name: MAIL_SENDER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: MAIL_SENDER_EMAIL
+            - name: MAIL_RECEIVER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: origins-cms-secrets
+                  key: MAIL_RECEIVER_EMAIL
             - name: VERSION
-              value: 0.1.0
+              value: 0.1.1
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-secrets-secret.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-secrets-secret.yaml
@@ -34,6 +34,30 @@ spec:
       key: pluto-origins-cms-secrets
       property: CLOUDINARY_API_FOLDER
       version: latest
+    - name: MAIL_HOST
+      key: pluto-origins-cms-secrets
+      property: MAIL_HOST
+      version: latest
+    - name: MAIL_USER
+      key: pluto-origins-cms-secrets
+      property: MAIL_USER
+      version: latest
+    - name: MAIL_PASSWORD
+      key: pluto-origins-cms-secrets
+      property: MAIL_PASSWORD
+      version: latest
+    - name: MAIL_SENDER_NAME
+      key: pluto-origins-cms-secrets
+      property: MAIL_SENDER_NAME
+      version: latest
+    - name: MAIL_SENDER_EMAIL
+      key: pluto-origins-cms-secrets
+      property: MAIL_SENDER_EMAIL
+      version: latest
+    - name: MAIL_RECEIVER_EMAIL
+      key: pluto-origins-cms-secrets
+      property: MAIL_RECEIVER_EMAIL
+      version: latest
   template:
     metadata:
       annotations:

--- a/config-root/namespaces/jx-staging/origins-cms/origins-cms-svc.yaml
+++ b/config-root/namespaces/jx-staging/origins-cms/origins-cms-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: origins-cms
   labels:
-    chart: "origins-cms-0.1.0"
+    chart: "origins-cms-0.1.1"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
-	      <td>0.1.0</td>
+	      <td>0.1.1</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -92,17 +92,17 @@
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
   - apiVersion: v1
-    appVersion: 0.1.0
+    appVersion: 0.1.1
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-05-02T10:45:32Z"
+    firstDeployed: "2022-05-10T15:31:57Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-05-02T10:45:32Z"
+    lastDeployed: "2022-05-10T15:31:57Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
     name: origins-cms
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/origins-cms
-    version: 0.1.0
+    version: 0.1.1
   - apiVersion: v1
     appVersion: 0.0.24
     description: Acme

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/origins-cms
-  version: 0.1.0
+  version: 0.1.1
   name: origins-cms
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote origins-cms to version 0.1.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
