### PR TITLE
chore: promote origins-cms to version 0.1.2

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/origins-cms
-  version: 0.1.1
+  version: 0.1.2
   name: origins-cms
   namespace: jx-production
   values:


### PR DESCRIPTION
chore: promote origins-cms to version 0.1.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
