### PR TITLE
chore: promote origins-cms to version 0.1.3

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-hitf8-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-hitf8-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-rvfr5
+  name: jx-verify-gc-jobs-hitf8
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-ezqwq
+    app: jx-verify-gc-jobs-mcldz
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-staging
+  namespace: jx-production
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-q9nbk-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-q9nbk-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-rfhbk
+  name: jx-verify-gc-jobs-q9nbk
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-deploy.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-origins-cms-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: origins-cms-origins-cms
   labels:
     draft: draft-app
-    chart: "origins-cms-0.1.1"
+    chart: "origins-cms-0.1.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: origins-cms-origins-cms
       containers:
         - name: origins-cms
-          image: "gcr.io/corded-imagery-343815/origins-cms:0.1.1"
+          image: "gcr.io/corded-imagery-343815/origins-cms:0.1.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: SESSION_SECRET
@@ -84,7 +84,7 @@ spec:
                   name: origins-cms-secrets
                   key: MAIL_RECEIVER_EMAIL
             - name: VERSION
-              value: 0.1.1
+              value: 0.1.3
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-production/origins-cms/origins-cms-svc.yaml
+++ b/config-root/namespaces/jx-production/origins-cms/origins-cms-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: origins-cms
   labels:
-    chart: "origins-cms-0.1.1"
+    chart: "origins-cms-0.1.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'origins-cms'

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-2bmn8-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-2bmn8-job.yaml
@@ -2,15 +2,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-nupqv
+  name: jx-verify-gc-jobs-2bmn8
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-orlsa
+    app: jx-verify-gc-jobs-kylnw
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
-  namespace: jx-production
+  namespace: jx-staging
 spec:
   backoffLimit: 1
   completions: 1

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-du6gv-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-du6gv-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-ywkb5
+  name: jx-verify-gc-jobs-du6gv
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
   <thead>
     <tr>
       <th scope="col">Release</th>
+      <th scope="col">Chart</th>
       <th scope="col">Version</th>
       <th scope="col">Open</th>
       <th scope="col">Source</th>
@@ -12,168 +13,192 @@
   </thead>
   <tbody>
     <tr>
-		      <td colspan='4'><h3>cert-manager</h3></td>
+		      <td colspan='5'><h3>cert-manager</h3></td>
 		    </tr>
 	    <tr>
+	      <td>cert-manager</td>
 	      <td><a href='https://github.com/jetstack/cert-manager' title='A Helm chart for cert-manager'> <img src='https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png' width='24px' height='24px'> cert-manager </a></td>
 	      <td>1.1.0</td>
 	      <td></td>
 	      <td><a href='https://github.com/jetstack/cert-manager'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>jx-production</h3></td>
+		      <td colspan='5'><h3>jx-production</h3></td>
 		    </tr>
 	    <tr>
+	      <td>jx-verify</td>
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify' title='This chart deletes any pods which can&#39;t load their images to work around timing issues with Workload Identity and preview environments '> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jx-verify </a></td>
 	      <td></td>
 	      <td></td>
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
-	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
-	      <td>0.1.1</td>
-	      <td></td>
-	      <td></td>
-	    </tr>
-    <tr>
-	      <td><a href='' title='Acme'> <img src='https://avatars2.githubusercontent.com/u/35583233?s=200&v=4' width='24px' height='24px'> acme </a></td>
-	      <td>0.0.24</td>
-	      <td></td>
-	      <td></td>
-	    </tr>
-    <tr>
-	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
-	      <td>0.0.22</td>
-	      <td></td>
-	      <td></td>
-	    </tr>
-    <tr>
-		      <td colspan='4'><h3>jx-staging</h3></td>
-		    </tr>
-	    <tr>
-	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify' title='This chart deletes any pods which can&#39;t load their images to work around timing issues with Workload Identity and preview environments '> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jx-verify </a></td>
-	      <td></td>
-	      <td></td>
-	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
-	    </tr>
-    <tr>
+	      <td>origins-cms</td>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
 	      <td>0.1.3</td>
 	      <td></td>
 	      <td></td>
 	    </tr>
     <tr>
+	      <td>acme-jx</td>
 	      <td><a href='' title='Acme'> <img src='https://avatars2.githubusercontent.com/u/35583233?s=200&v=4' width='24px' height='24px'> acme </a></td>
 	      <td>0.0.24</td>
 	      <td></td>
 	      <td></td>
 	    </tr>
     <tr>
+	      <td>unocoins</td>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
 	      <td>0.0.22</td>
 	      <td></td>
 	      <td></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>jx</h3></td>
+		      <td colspan='5'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>
-	      <td><a href='https://github.com/bitnami/charts/tree/master/bitnami/external-dns' title='ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.'> <img src='https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-220x234.png' width='24px' height='24px'> external-dns </a></td>
-	      <td>6.0.2</td>
+	      <td>jx-verify</td>
+	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify' title='This chart deletes any pods which can&#39;t load their images to work around timing issues with Workload Identity and preview environments '> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jx-verify </a></td>
 	      <td></td>
-	      <td><a href='https://github.com/bitnami/charts/tree/master/bitnami/external-dns'>source</a></td>
+	      <td></td>
+	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td>origins-cms</td>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> origins-cms </a></td>
+	      <td>0.1.3</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
+	      <td>acme-jx</td>
 	      <td><a href='' title='Acme'> <img src='https://avatars2.githubusercontent.com/u/35583233?s=200&v=4' width='24px' height='24px'> acme </a></td>
 	      <td>0.0.24</td>
 	      <td></td>
 	      <td></td>
 	    </tr>
     <tr>
+	      <td>unocoins</td>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> unocoins </a></td>
+	      <td>0.0.22</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
+		      <td colspan='5'><h3>jx</h3></td>
+		    </tr>
+	    <tr>
+	      <td>external-dns</td>
+	      <td><a href='https://github.com/bitnami/charts/tree/master/bitnami/external-dns' title='ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.'> <img src='https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-220x234.png' width='24px' height='24px'> external-dns </a></td>
+	      <td>6.0.2</td>
+	      <td></td>
+	      <td><a href='https://github.com/bitnami/charts/tree/master/bitnami/external-dns'>source</a></td>
+	    </tr>
+    <tr>
+	      <td>acme-jx</td>
+	      <td><a href='' title='Acme'> <img src='https://avatars2.githubusercontent.com/u/35583233?s=200&v=4' width='24px' height='24px'> acme </a></td>
+	      <td>0.0.24</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
+	      <td>jxboot-helmfile-resources</td>
 	      <td><a href='https://github.com/jenkins-x-charts/jxboot-helmfile-resources' title='A Helm chart for the resources for JX Boot'> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jxboot-helmfile-resources </a></td>
 	      <td>1.1.38</td>
 	      <td></td>
 	      <td><a href='https://github.com/jenkins-x-charts/jxboot-helmfile-resources'>source</a></td>
 	    </tr>
     <tr>
+	      <td>jx-pipelines-visualizer</td>
 	      <td><a href='https://github.com/jenkins-x/jx-pipelines-visualizer' title='Web UI for Jenkins X, with a clear goal - visualize the pipelines - and their logs.'> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jx-pipelines-visualizer </a></td>
 	      <td>1.8.0</td>
 	      <td></td>
 	      <td><a href='https://github.com/jenkins-x/jx-pipelines-visualizer'>source</a></td>
 	    </tr>
     <tr>
+	      <td>jx-preview</td>
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-preview' title='This chart installs the jx-preview CRD and garbagecollection job '> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jx-preview </a></td>
 	      <td>0.0.194</td>
 	      <td></td>
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-preview'>source</a></td>
 	    </tr>
     <tr>
+	      <td>lighthouse</td>
 	      <td><a href='https://github.com/jenkins-x/lighthouse' title='This chart bootstraps installation of [Lighthouse](https://github.com/jenkins-x/lighthouse). '> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> lighthouse </a></td>
 	      <td>1.5.13</td>
 	      <td></td>
 	      <td><a href='https://github.com/jenkins-x/lighthouse'>source</a></td>
 	    </tr>
     <tr>
+	      <td>nexus</td>
 	      <td><a href='https://github.com/jenkins-x-charts/nexus' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/jenkins-x-platform/images/nexus.png' width='24px' height='24px'> nexus </a></td>
 	      <td>0.1.41</td>
 	      <td></td>
 	      <td><a href='https://github.com/jenkins-x-charts/nexus'>source</a></td>
 	    </tr>
     <tr>
+	      <td>chartmuseum</td>
 	      <td><a href='https://github.com/helm/chartmuseum' title='DEPRECATED Host your own Helm Chart Repository'> <img src='https://raw.githubusercontent.com/helm/chartmuseum/master/logo2.png' width='24px' height='24px'> chartmuseum </a></td>
 	      <td>2.14.2</td>
 	      <td></td>
 	      <td><a href='https://github.com/helm/chartmuseum'>source</a></td>
 	    </tr>
     <tr>
+	      <td>jx-build-controller</td>
 	      <td><a href='https://jenkins-x.io/' title='Jenkins X next gen cloud CI / CD platform for Kubernetes'> <img src='https://raw.githubusercontent.com/jenkins-x/jenkins-x-website/master/images/logo/jenkinsx-icon-color.svg' width='24px' height='24px'> jx-build-controller </a></td>
 	      <td>0.3.9</td>
 	      <td></td>
 	      <td><a href='https://jenkins-x.io/'>source</a></td>
 	    </tr>
     <tr>
+	      <td>health-checks-jx</td>
 	      <td><a href='https://jenkins-x.io/' title='Jenkins X next gen cloud CI / CD platform for Kubernetes'> <img src='https://jenkins-x.github.io/jenkins-x-website/img/profile.png' width='24px' height='24px'> jx-kh-check </a></td>
 	      <td>0.0.78</td>
 	      <td></td>
 	      <td><a href='https://jenkins-x.io/'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>kuberhealthy</h3></td>
+		      <td colspan='5'><h3>kuberhealthy</h3></td>
 		    </tr>
 	    <tr>
+	      <td>kh-tls-check</td>
 	      <td><a href='https://jenkins-x.io/' title='Jenkins X next gen cloud CI / CD platform for Kubernetes'> <img src='https://jenkins-x.github.io/jenkins-x-website/img/profile.png' width='24px' height='24px'> kh-tls-check </a></td>
 	      <td>0.0.10</td>
 	      <td></td>
 	      <td><a href='https://jenkins-x.io/'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>nginx</h3></td>
+		      <td colspan='5'><h3>nginx</h3></td>
 		    </tr>
 	    <tr>
+	      <td>nginx-ingress</td>
 	      <td><a href='https://github.com/kubernetes/ingress-nginx' title='Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer'> <img src='https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Nginx_logo.svg/500px-Nginx_logo.svg.png' width='24px' height='24px'> ingress-nginx </a></td>
 	      <td>3.12.0</td>
 	      <td></td>
 	      <td><a href='https://github.com/kubernetes/ingress-nginx'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>secret-infra</h3></td>
+		      <td colspan='5'><h3>secret-infra</h3></td>
 		    </tr>
 	    <tr>
+	      <td>kubernetes-external-secrets</td>
 	      <td><a href='https://github.com/external-secrets/kubernetes-external-secrets' title='Kubernetes External Secrets CustomResourceDefinition'> <img src='' width='24px' height='24px'> kubernetes-external-secrets </a></td>
 	      <td>8.3.0</td>
 	      <td></td>
 	      <td><a href='https://github.com/external-secrets/kubernetes-external-secrets'>source</a></td>
 	    </tr>
     <tr>
+	      <td>pusher-wave</td>
 	      <td><a href='https://github.com/pusher/wave' title='wave chart that runs on kubernetes'> <img src='' width='24px' height='24px'> pusher-wave </a></td>
 	      <td>0.4.21</td>
 	      <td></td>
 	      <td><a href='https://github.com/pusher/wave'>source</a></td>
 	    </tr>
     <tr>
-		      <td colspan='4'><h3>tekton-pipelines</h3></td>
+		      <td colspan='5'><h3>tekton-pipelines</h3></td>
 		    </tr>
 	    <tr>
+	      <td>tekton-pipeline</td>
 	      <td><a href='https://github.com/cdfoundation/tekton-helm-chart' title='A Helm chart for Tekton Pipelines'> <img src='https://avatars2.githubusercontent.com/u/47602533' width='24px' height='24px'> tekton-pipeline </a></td>
 	      <td>0.27.2</td>
 	      <td></td>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -18,6 +18,7 @@
     - email: james@jetstack.io
       name: munnerz
     name: cert-manager
+    releaseName: cert-manager
     repositoryName: jetstack
     repositoryUrl: https://charts.jetstack.io
     resourcePath: config-root/namespaces/cert-manager/cert-manager
@@ -37,21 +38,23 @@
     lastDeployed: "2022-03-20T10:24:16Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fjx-verify&dateRangeUnbound=both
     name: jx-verify
+    releaseName: jx-verify
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-production/jx-verify
   - apiVersion: v1
-    appVersion: 0.1.1
+    appVersion: 0.1.3
     description: A Helm chart for Kubernetes
-    firstDeployed: "2022-05-10T15:37:29Z"
+    firstDeployed: "2022-05-21T02:27:47Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2022-05-10T15:37:29Z"
+    lastDeployed: "2022-05-21T02:27:47Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
     name: origins-cms
+    releaseName: origins-cms
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-production/origins-cms
-    version: 0.1.1
+    version: 0.1.3
   - apiVersion: v1
     appVersion: 0.0.24
     description: Acme
@@ -60,6 +63,7 @@
     lastDeployed: "2022-03-21T09:13:12Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Facme&dateRangeUnbound=both
     name: acme
+    releaseName: acme-jx
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
@@ -71,6 +75,7 @@
     lastDeployed: "2022-04-28T10:33:29Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
     name: unocoins
+    releaseName: unocoins
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-production/unocoins
@@ -88,6 +93,7 @@
     lastDeployed: "2022-03-20T10:24:30Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fjx-verify&dateRangeUnbound=both
     name: jx-verify
+    releaseName: jx-verify
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx-staging/jx-verify
@@ -99,6 +105,7 @@
     lastDeployed: "2022-05-21T01:52:15Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Forigins-cms&dateRangeUnbound=both
     name: origins-cms
+    releaseName: origins-cms
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/origins-cms
@@ -111,6 +118,7 @@
     lastDeployed: "2022-03-21T09:13:21Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Facme&dateRangeUnbound=both
     name: acme
+    releaseName: acme-jx
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
@@ -122,6 +130,7 @@
     lastDeployed: "2022-04-28T09:21:53Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Funocoins&dateRangeUnbound=both
     name: unocoins
+    releaseName: unocoins
     repositoryName: dev
     repositoryUrl: https://chartmuseum.pluto.binomy.io
     resourcePath: config-root/namespaces/jx-staging/unocoins
@@ -154,6 +163,7 @@
     - email: containers@bitnami.com
       name: Bitnami
     name: external-dns
+    releaseName: external-dns
     repositoryName: bitnami
     repositoryUrl: https://charts.bitnami.com/bitnami
     resourcePath: config-root/namespaces/jx/external-dns
@@ -170,6 +180,7 @@
     lastDeployed: "2022-03-20T10:25:40Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx%2Fcontainer_name%2Facme&dateRangeUnbound=both
     name: acme
+    releaseName: acme-jx
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     version: 0.0.24
@@ -182,6 +193,7 @@
     lastDeployed: "2022-03-20T10:25:45Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx%2Fcontainer_name%2Fjxboot-helmfile-resources&dateRangeUnbound=both
     name: jxboot-helmfile-resources
+    releaseName: jxboot-helmfile-resources
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx/jxboot-helmfile-resources
@@ -196,6 +208,7 @@
     lastDeployed: "2022-03-20T10:25:50Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx%2Fcontainer_name%2Fjx-pipelines-visualizer&dateRangeUnbound=both
     name: jx-pipelines-visualizer
+    releaseName: jx-pipelines-visualizer
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx/jx-pipelines-visualizer
@@ -210,6 +223,7 @@
     lastDeployed: "2022-03-20T10:25:55Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx%2Fcontainer_name%2Fjx-preview&dateRangeUnbound=both
     name: jx-preview
+    releaseName: jx-preview
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx/jx-preview
@@ -222,6 +236,7 @@
     lastDeployed: "2022-03-20T10:26:00Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx%2Fcontainer_name%2Flighthouse&dateRangeUnbound=both
     name: lighthouse
+    releaseName: lighthouse
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx/lighthouse
@@ -235,6 +250,7 @@
     lastDeployed: "2022-03-20T10:26:04Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx%2Fcontainer_name%2Fnexus&dateRangeUnbound=both
     name: nexus
+    releaseName: nexus
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx/nexus
@@ -253,6 +269,7 @@
     lastDeployed: "2022-03-20T10:26:13Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fjx%2Fcontainer_name%2Fchartmuseum&dateRangeUnbound=both
     name: chartmuseum
+    releaseName: chartmuseum
     repositoryName: stable
     repositoryUrl: https://charts.helm.sh/stable
     resourcePath: config-root/namespaces/jx/chartmuseum
@@ -269,6 +286,7 @@
     - email: jenkins-x@googlegroups.com
       name: Jenkins X Team
     name: jx-build-controller
+    releaseName: jx-build-controller
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx/jx-build-controller
@@ -287,6 +305,7 @@
     - email: jenkins-x@googlegroups.com
       name: Jenkins X Team
     name: jx-kh-check
+    releaseName: health-checks-jx
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/jx/jx-kh-check-health-checks-jx
@@ -308,6 +327,7 @@
     - email: jenkins-x@googlegroups.com
       name: Jenkins X Team
     name: kh-tls-check
+    releaseName: kh-tls-check
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/kuberhealthy/kh-tls-check
@@ -336,6 +356,7 @@
     maintainers:
     - name: ChiefAlexander
     name: ingress-nginx
+    releaseName: nginx-ingress
     repositoryName: ingress-nginx
     repositoryUrl: https://kubernetes.github.io/ingress-nginx
     resourcePath: config-root/namespaces/nginx/ingress-nginx-nginx-ingress
@@ -360,6 +381,7 @@
     - name: external-secrets
       url: https://github.com/external-secrets
     name: kubernetes-external-secrets
+    releaseName: kubernetes-external-secrets
     repositoryName: external-secrets
     repositoryUrl: https://external-secrets.github.io/kubernetes-external-secrets
     resourcePath: config-root/namespaces/secret-infra/kubernetes-external-secrets
@@ -377,6 +399,7 @@
     lastDeployed: "2022-03-20T10:27:00Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Fsecret-infra%2Fcontainer_name%2Fpusher-wave&dateRangeUnbound=both
     name: pusher-wave
+    releaseName: pusher-wave
     repositoryName: jxgh
     repositoryUrl: https://jenkins-x-charts.github.io/repo
     resourcePath: config-root/namespaces/secret-infra/pusher-wave
@@ -395,6 +418,7 @@
     lastDeployed: "2022-03-20T10:27:11Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=corded-imagery-343815&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fpluto%2Fnamespace_name%2Ftekton-pipelines%2Fcontainer_name%2Ftekton-pipeline&dateRangeUnbound=both
     name: tekton-pipeline
+    releaseName: tekton-pipeline
     repositoryName: cdf
     repositoryUrl: https://cdfoundation.github.io/tekton-helm-chart
     resourcePath: config-root/namespaces/tekton-pipelines/tekton-pipeline

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/origins-cms
-  version: 0.1.1
+  version: 0.1.3
   name: origins-cms
   namespace: jx-production
   values:


### PR DESCRIPTION
chore: promote origins-cms to version 0.1.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
